### PR TITLE
SixDB simplification

### DIFF
--- a/lib/dbadaptor.py
+++ b/lib/dbadaptor.py
@@ -5,7 +5,7 @@ import sqlite3
 import pymysql
 import collections
 import traceback
-from constants import closing
+from contextlib import closing
 from abc import ABC, abstractmethod
 
 
@@ -254,7 +254,8 @@ class SQLDatabaseAdaptor(DatabaseAdaptor):
     def fetch_tables(self):
         '''Fetch all the table names in the database'''
         with closing(self.conn.cursor()) as c:
-            out = c.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            c.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            out = c.fetchall()
         return list(out)
 
     def insert(self, table_name, values):

--- a/lib/dbadaptor.py
+++ b/lib/dbadaptor.py
@@ -155,7 +155,7 @@ class DatabaseAdaptor(ABC):
             c.execute(sql_cmd, vals)
         conn.commit()
 
-    def remove(self, conn, table_name, where):
+    def delete(self, conn, table_name, where):
         '''Remove rows based on specified conditions
         @conn A connection of database
         @table_name(str) The table name

--- a/lib/dbadaptor.py
+++ b/lib/dbadaptor.py
@@ -184,9 +184,10 @@ class DatabaseAdaptor(ABC):
         self.conn.commit()
 
     def close(self):
-        '''Disconnect the database'''
-        self.conn.commit()
-        self.conn.close()
+        '''Disconnect the database, if a connection is active'''
+        if self.conn is not None:
+            self.conn.commit()
+            self.conn.close()
 
     def __del__(self):
         '''Disconnect before deletion'''
@@ -267,7 +268,7 @@ class SQLDatabaseAdaptor(DatabaseAdaptor):
 class MySQLDatabaseAdaptor(DatabaseAdaptor):
 
     def _check(self):
-        if self.info_check():
+        if self._info_check():
             if self.create:
                 self.create_db(**self.db_info)
         else:
@@ -327,7 +328,7 @@ class MySQLDatabaseAdaptor(DatabaseAdaptor):
             utils.message('Warning', content, self.mes_level, self.log_file)
 
     def new_connection(self, host, user, passwd, db_name, **kwargs):
-        '''Connect to an exist database'''
+        '''Connect to an existing database'''
         conn = pymysql.connect(host, user, passwd, db_name, **kwargs)
         return conn
 

--- a/lib/dbadaptor.py
+++ b/lib/dbadaptor.py
@@ -104,7 +104,8 @@ class DatabaseAdaptor(ABC):
             c.executemany(sql_cmd, vals)
         conn.commit()
 
-    def select(self, conn, table_name, cols='*', where=None, orderby=None, **kwargs):
+    def select(self, conn, table_name, cols='*', where=None, orderby=None,
+               **kwargs):
         '''Select values with conditions
         @conn A connection of database
         @table_name(str) The table name
@@ -115,7 +116,8 @@ class DatabaseAdaptor(ABC):
         '''
         if len(cols) == 0:
             return []
-        if (isinstance(cols, collections.Iterable) and not isinstance(cols, str)):
+        if (isinstance(cols, collections.Iterable) and not isinstance(cols,
+                                                                      str)):
             cols = [i.replace('.', '_') for i in cols]
             cols = ','.join(cols)
         sql = 'SELECT %s FROM %s' % (cols, table_name)
@@ -130,7 +132,7 @@ class DatabaseAdaptor(ABC):
             data = c.fetchall()
         return data
 
-    def update(self, conn, table_name, values, ph, where=None):
+    def update(self, conn, table_name, values, where, ph):
         '''Update data in a table
         @conn A connection of database
         @table_name(str) The table name
@@ -169,6 +171,9 @@ class DatabaseAdaptor(ABC):
 
 class SQLDatabaseAdaptor(DatabaseAdaptor):
 
+    def __init__(self, mes_level=1, log_file=None):
+        super().__init__(mes_level=mes_level, log_file=log_file)
+
     def new_connection(self, db_name, **kwargs):
         '''Create a new connection'''
         if '.db' not in db_name:
@@ -193,7 +198,8 @@ class SQLDatabaseAdaptor(DatabaseAdaptor):
                 for ky in auto_keys:
                     if ky in prim_keys and columns[ky] != 'INTEGER':
                         columns[ky] = 'INTEGER'
-        super(SQLDatabaseAdaptor, self).create_table(conn, name, columns, keys, recreate)
+        super(SQLDatabaseAdaptor, self).create_table(conn, name, columns, keys,
+                                                     recreate)
 
     def fetch_tables(self, conn):
         '''Fetch all the table names in the database'''
@@ -210,12 +216,16 @@ class SQLDatabaseAdaptor(DatabaseAdaptor):
         '''Insert multi rows of values'''
         super(SQLDatabaseAdaptor, self).insertm(conn, table_name, values, '?')
 
-    def update(self, conn, table_name, values, where=None):
+    def update(self, conn, table_name, values, where):
         '''update values'''
-        super(SQLDatabaseAdaptor, self).update(conn, table_name, values, '?', where=where)
+        super(SQLDatabaseAdaptor, self).update(conn, table_name, values, where,
+                                               '?')
 
 
 class MySQLDatabaseAdaptor(DatabaseAdaptor):
+
+    def __init__(self, mes_level=1, log_file=None):
+        super().__init__(mes_level=mes_level, log_file=log_file)
 
     def create_db(self, host, user, passwd, db_name, **kwargs):
         '''Create a new database'''
@@ -261,7 +271,8 @@ class MySQLDatabaseAdaptor(DatabaseAdaptor):
 
     def create_table(self, conn, name, columns, keys, recreate):
         '''Create a new table'''
-        super(MySQLDatabaseAdaptor, self).create_table(conn, name, columns, keys, recreate)
+        super(MySQLDatabaseAdaptor, self).create_table(conn, name, columns,
+                                                       keys, recreate)
 
     def fetch_tables(self, conn):
         '''Fetch all the table names in the database'''
@@ -272,12 +283,15 @@ class MySQLDatabaseAdaptor(DatabaseAdaptor):
 
     def insert(self, conn, table_name, values):
         '''Insert a row of values'''
-        super(MySQLDatabaseAdaptor, self).insert(conn, table_name, values, '%s')
+        super(MySQLDatabaseAdaptor, self).insert(conn, table_name, values,
+                                                 '%s')
 
     def insertm(self, conn, table_name, values):
         '''Insert multi rows of values'''
-        super(MySQLDatabaseAdaptor, self).insertm(conn, table_name, values, '%s')
+        super(MySQLDatabaseAdaptor, self).insertm(conn, table_name, values,
+                                                  '%s')
 
-    def update(self, conn, table_name, values, where=None):
+    def update(self, conn, table_name, values, where):
         '''update values'''
-        super(MySQLDatabaseAdaptor, self).update(conn, table_name, values, '%s', where=where)
+        super(MySQLDatabaseAdaptor, self).update(conn, table_name, values,
+                                                 where, '%s')

--- a/lib/dbadaptor.py
+++ b/lib/dbadaptor.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import utils
 import sqlite3
@@ -22,14 +21,6 @@ class DatabaseAdaptor(ABC):
     @abstractmethod
     def setting(self, conn, settings):
         pass
-
-    def create_tables(self, conn, tables, tables_keys={}, recreate=False):
-        '''Create multiple tables'''
-        for key, value in tables.items():
-            key_info = {}
-            if key in tables_keys.keys():
-                key_info = tables_keys[key]
-            self.create_table(conn, key, value, key_info, recreate)
 
     def create_table(self, conn, name, columns, keys, recreate):
         '''Create a new table'''
@@ -74,6 +65,7 @@ class DatabaseAdaptor(ABC):
 
     def insert(self, conn, table_name, values, ph):
         '''Insert a row of values
+        @conn A connection of database
         @table_name(str) The table name
         @values(dict) The values required to insert into database
         @ph The placeholder for the selected database, e.g. ?, %s
@@ -93,6 +85,7 @@ class DatabaseAdaptor(ABC):
 
     def insertm(self, conn, table_name, values, ph):
         '''Insert multiple rows once
+        @conn A connection of database
         @table_name(str) The table name
         @values(dict) The values required to insert into database
         @ph The placeholder for the selected database, e.g. ?, %s
@@ -113,6 +106,7 @@ class DatabaseAdaptor(ABC):
 
     def select(self, conn, table_name, cols='*', where=None, orderby=None, **kwargs):
         '''Select values with conditions
+        @conn A connection of database
         @table_name(str) The table name
         @cols(list) The column names
         @where(str) Selection condition
@@ -138,6 +132,7 @@ class DatabaseAdaptor(ABC):
 
     def update(self, conn, table_name, values, ph, where=None):
         '''Update data in a table
+        @conn A connection of database
         @table_name(str) The table name
         @values(dict) The column names with new values
         @where(str) Selection condition
@@ -162,6 +157,7 @@ class DatabaseAdaptor(ABC):
 
     def remove(self, conn, table_name, where):
         '''Remove rows based on specified conditions
+        @conn A connection of database
         @table_name(str) The table name
         @where(str) Selection condition which is mandatory here!
         '''

--- a/lib/pysixdb.py
+++ b/lib/pysixdb.py
@@ -1,145 +1,31 @@
-import os
 import sys
 import utils
 import dbadaptor
 
 
-class SixDB(object):
+def SixDB(db_info, settings=None, create=False, mes_level=1, log_file=None):
+    '''
+    Figures out which dbadaptor to use.
 
-    def __init__(self, db_info, settings=None, create=False, mes_level=1,
-                 log_file=None):
-        '''Constructor.
-        db_info(dict): contain the information of the database,
-                       such as db_name, type, user, password, host and so on
-        For sqlite db only db_name is needed which should be an absolute path,
-        For MySQL db db_info should contain db_name(just name), user,
-        password, host, port and other optional arguments.
-        '''
-        self.settings = settings
-        self.create = create
-        self.mes_level = 1
-        self.log_file = log_file
-        info = {}
-        info.update(db_info)
-        self._setup(info)
+    @db_info: dict containing the required database information
+    @settings: databse settings, i.e. pragmas
+    @create: bool controls whethter to create the db
+    @mes_level: controls the messaging level, see utils.message
+    @log_file: if provided, the utils.message write to provided file
+    '''
+    db_info = db_info.copy()
+    if 'db_type' not in db_info.keys():
+        dbtype = 'sql'
+    else:
+        dbtype = db_info.pop('db_type')
 
-    def _setup(self, db_info):
-        '''Setup the database'''
-        if 'db_type' not in db_info.keys():
-            dbtype = 'sql'
-        else:
-            dbtype = db_info.pop('db_type')
-        if dbtype.lower() == 'sql':
-            self.adaptor = dbadaptor.SQLDatabaseAdaptor(self.mes_level,
-                                                        self.log_file)
-            status = self.info_check(dbtype, db_info)
-            if status:
-                name = db_info['db_name']
-                if not self.create and not os.path.exists(name):
-                    content = "The database %s doesn't exist!" % name
-                    utils.message('Error', content, self.mes_level,
-                                  self.log_file)
-                    sys.exit(1)
-            else:
-                content = "Something wrong with db info %s!" % str(db_info)
-                utils.message('Error', content, self.mes_level, self.log_file)
-                sys.exit(1)
-        elif dbtype.lower() == 'mysql':
-            self.adaptor = dbadaptor.MySQLDatabaseAdaptor(self.mes_level,
-                                                          self.log_file)
-            status = self.info_check(dbtype, db_info)
-            if status:
-                if self.create:
-                    self.adaptor.create_db(**db_info)
-            else:
-                content = "Something wrong with db info %s!" % str(db_info)
-                utils.message('Error', content, self.mes_level, self.log_file)
-                sys.exit(1)
-        else:
-            content = "Unkonw database type %s!" % dbtype
-            utils.message('Error', content, self.mes_level, self.log_file)
-            sys.exit(1)
-
-        self.conn = self.adaptor.new_connection(**db_info)
-        if self.settings is not None:
-            self.setting(self.settings)
-
-    def setting(self, settings):
-        '''Execute the settings of the database'''
-        self.adaptor.setting(self.conn, settings)
-
-    def info_check(self, dbtype, db_info):
-        '''Check if all the necessary information for database is there.
-        And  check if the parameter's type is correct, if not, correct it'''
-        if dbtype == 'sql':
-            if 'db_name' in db_info:
-                if not isinstance(db_info['db_name'], str):
-                    db_info['db_name'] = str(db_info['db_name'])
-                return True
-            else:
-                return False
-        elif dbtype == 'mysql':
-            if ('port' in db_info and 'user' in db_info and 'host' in db_info
-                    and 'passwd' in db_info and 'db_name' in db_info):
-                if not isinstance(db_info['port'], int):
-                    db_info['port'] = int(db_info['port'])
-                if not isinstance(db_info['user'], str):
-                    db_info['user'] = str(db_info['user'])
-                if not isinstance(db_info['host'], str):
-                    db_info['host'] = str(db_info['host'])
-                if not isinstance(db_info['passwd'], str):
-                    db_info['passwd'] = str(db_info['passwd'])
-                if not isinstance(db_info['db_name'], str):
-                    db_info['db_name'] = str(db_info['db_name'])
-                return True
-            else:
-                return False
-
-    def fetch_tables(self):
-        '''Get all the table names in the database'''
-        r = self.adaptor.fetch_tables(self.conn)
-        return r
-
-    def create_table(self, table_name, table_info, key_info={}, recreate=False):
-        '''Create a new table or recreate an existing table'''
-        self.adaptor.create_table(self.conn, table_name, table_info, key_info,
-                                  recreate)
-
-    def create_tables(self, tables, tables_keys={}, recreate=False):
-        '''Create multiple tables'''
-        for key, value in tables.items():
-            key_info = {}
-            if key in tables_keys.keys():
-                key_info = tables_keys[key]
-            self.create_table(key, value, key_info, recreate)
-
-    def drop_table(self, table_name):
-        '''Drop a table'''
-        self.adaptor.drop_table(self.conn, table_name)
-
-    def insert(self, table_name, values):
-        '''Insert a row of values'''
-        self.adaptor.insert(self.conn, table_name, values)
-
-    def insertm(self, table_name, values):
-        '''Insert multiple rows'''
-        self.adaptor.insertm(self.conn, table_name, values)
-
-    def select(self, table_name, columns='*', where=None, orderby=None, **kwargs):
-        '''Select values with specified conditions'''
-        r = self.adaptor.select(self.conn, table_name, columns, where, orderby,
-                                **kwargs)
-        return r
-
-    def update(self, table_name, values, where=None):
-        '''Update data in a table'''
-        self.adaptor.update(self.conn, table_name, values, where)
-
-    def remove(self, table_name, where):
-        '''Reomve rows based on specified conditions'''
-        self.adaptor.delete(self.conn, table_name, where)
-
-    def close(self):
-        '''Disconnect the database'''
-        self.conn.commit()
-        self.conn.close()
+    if dbtype == 'sql':
+        return dbadaptor.SQLDatabaseAdaptor(db_info, settings=settings, create=create,
+                                            mes_level=mes_level, log_file=log_file)
+    elif dbtype == 'mysql':
+        return dbadaptor.MySQLDatabaseAdaptor(db_info, settings=settings, create=create,
+                                            mes_level=mes_level, log_file=log_file)
+    else:
+        content = "Unknown database type %s!" % dbtype
+        utils.message('Error', content, mes_level, log_file)
+        sys.exit(1)

--- a/lib/pysixdb.py
+++ b/lib/pysixdb.py
@@ -56,7 +56,7 @@ class SixDB(object):
                 utils.message('Error', content, self.mes_level, self.log_file)
                 sys.exit(1)
         else:
-            content = "Unkonw database type %s!" % dbtype
+            content = "Unkown database type %s!" % dbtype
             utils.message('Error', content, self.mes_level, self.log_file)
             sys.exit(1)
 
@@ -146,7 +146,8 @@ class SixDB(object):
 
     def __del__(self):
         try:
-            self.conn.commit()
-            self.conn.close()
+            self.close()
+            content = "Closed database connection."
+            utils.message('Message', content, self.mes_level, self.log_file)
         except Exception:
             pass

--- a/lib/pysixdb.py
+++ b/lib/pysixdb.py
@@ -1,31 +1,152 @@
+import os
 import sys
 import utils
 import dbadaptor
 
 
-def SixDB(db_info, settings=None, create=False, mes_level=1, log_file=None):
-    '''
-    Figures out which dbadaptor to use.
+class SixDB(object):
 
-    @db_info: dict containing the required database information
-    @settings: databse settings, i.e. pragmas
-    @create: bool controls whether to create the db
-    @mes_level: controls the messaging level, see utils.message
-    @log_file: if provided, utils.message writes to the provided file
-    '''
-    db_info = db_info.copy()
-    if 'db_type' not in db_info.keys():
-        dbtype = 'sql'
-    else:
-        dbtype = db_info.pop('db_type')
+    def __init__(self, db_info, settings=None, create=False, mes_level=1,
+                 log_file=None):
+        '''Constructor.
+        db_info(dict): contain the information of the database,
+                       such as db_name, type, user, password, host and so on
+        For sqlite db only db_name is needed which should be an absolute path,
+        For MySQL db db_info should contain db_name(just name), user,
+        password, host, port and other optional arguments.
+        '''
+        self.settings = settings
+        self.create = create
+        self.mes_level = mes_level
+        self.log_file = log_file
+        info = {}
+        info.update(db_info)
+        self._setup(info)
 
-    if dbtype == 'sql':
-        return dbadaptor.SQLDatabaseAdaptor(db_info, settings=settings, create=create,
-                                            mes_level=mes_level, log_file=log_file)
-    elif dbtype == 'mysql':
-        return dbadaptor.MySQLDatabaseAdaptor(db_info, settings=settings, create=create,
-                                            mes_level=mes_level, log_file=log_file)
-    else:
-        content = "Unknown database type %s!" % dbtype
-        utils.message('Error', content, mes_level, log_file)
-        sys.exit(1)
+    def _setup(self, db_info):
+        '''Setup the database'''
+        if 'db_type' not in db_info.keys():
+            dbtype = 'sql'
+        else:
+            dbtype = db_info.pop('db_type')
+        if dbtype.lower() == 'sql':
+            self.adaptor = dbadaptor.SQLDatabaseAdaptor(self.mes_level,
+                                                        self.log_file)
+            status = self.info_check(dbtype, db_info)
+            if status:
+                name = db_info['db_name']
+                if not self.create and not os.path.exists(name):
+                    content = "The database %s doesn't exist!" % name
+                    utils.message('Error', content, self.mes_level,
+                                  self.log_file)
+                    sys.exit(1)
+            else:
+                content = "Something wrong with db info %s!" % str(db_info)
+                utils.message('Error', content, self.mes_level, self.log_file)
+                sys.exit(1)
+        elif dbtype.lower() == 'mysql':
+            self.adaptor = dbadaptor.MySQLDatabaseAdaptor(self.mes_level,
+                                                          self.log_file)
+            status = self.info_check(dbtype, db_info)
+            if status:
+                if self.create:
+                    self.adaptor.create_db(**db_info)
+            else:
+                content = "Something wrong with db info %s!" % str(db_info)
+                utils.message('Error', content, self.mes_level, self.log_file)
+                sys.exit(1)
+        else:
+            content = "Unkonw database type %s!" % dbtype
+            utils.message('Error', content, self.mes_level, self.log_file)
+            sys.exit(1)
+
+        self.conn = self.adaptor.new_connection(**db_info)
+        if self.settings is not None:
+            self.setting(self.settings)
+
+    def setting(self, settings):
+        '''Execute the settings of the database'''
+        self.adaptor.setting(self.conn, settings)
+
+    def info_check(self, dbtype, db_info):
+        '''Check if all the necessary information for database is there.
+        And  check if the parameter's type is correct, if not, correct it'''
+        if dbtype == 'sql':
+            if 'db_name' in db_info:
+                if not isinstance(db_info['db_name'], str):
+                    db_info['db_name'] = str(db_info['db_name'])
+                return True
+            else:
+                return False
+        elif dbtype == 'mysql':
+            if ('port' in db_info and 'user' in db_info and 'host' in db_info
+                    and 'passwd' in db_info and 'db_name' in db_info):
+                if not isinstance(db_info['port'], int):
+                    db_info['port'] = int(db_info['port'])
+                if not isinstance(db_info['user'], str):
+                    db_info['user'] = str(db_info['user'])
+                if not isinstance(db_info['host'], str):
+                    db_info['host'] = str(db_info['host'])
+                if not isinstance(db_info['passwd'], str):
+                    db_info['passwd'] = str(db_info['passwd'])
+                if not isinstance(db_info['db_name'], str):
+                    db_info['db_name'] = str(db_info['db_name'])
+                return True
+            else:
+                return False
+
+    def fetch_tables(self):
+        '''Get all the table names in the database'''
+        r = self.adaptor.fetch_tables(self.conn)
+        return r
+
+    def create_table(self, table_name, table_info, key_info={}, recreate=False):
+        '''Create a new table or recreate an existing table'''
+        self.adaptor.create_table(self.conn, table_name, table_info, key_info,
+                                  recreate)
+
+    def create_tables(self, tables, tables_keys={}, recreate=False):
+        '''Create multiple tables'''
+        for key, value in tables.items():
+            key_info = {}
+            if key in tables_keys.keys():
+                key_info = tables_keys[key]
+            self.create_table(key, value, key_info, recreate)
+
+    def drop_table(self, table_name):
+        '''Drop a table'''
+        self.adaptor.drop_table(self.conn, table_name)
+
+    def insert(self, table_name, values):
+        '''Insert a row of values'''
+        self.adaptor.insert(self.conn, table_name, values)
+
+    def insertm(self, table_name, values):
+        '''Insert multiple rows'''
+        self.adaptor.insertm(self.conn, table_name, values)
+
+    def select(self, table_name, columns='*', where=None, orderby=None, **kwargs):
+        '''Select values with specified conditions'''
+        r = self.adaptor.select(self.conn, table_name, columns, where, orderby,
+                                **kwargs)
+        return r
+
+    def update(self, table_name, values, where=None):
+        '''Update data in a table'''
+        self.adaptor.update(self.conn, table_name, values, where)
+
+    def remove(self, table_name, where):
+        '''Reomve rows based on specified conditions'''
+        self.adaptor.delete(self.conn, table_name, where)
+
+    def close(self):
+        '''Disconnect the database'''
+        self.conn.commit()
+        self.conn.close()
+
+    def __del__(self):
+        try:
+            self.conn.commit()
+            self.conn.close()
+        except Exception:
+            pass

--- a/lib/pysixdb.py
+++ b/lib/pysixdb.py
@@ -9,7 +9,7 @@ def SixDB(db_info, settings=None, create=False, mes_level=1, log_file=None):
 
     @db_info: dict containing the required database information
     @settings: databse settings, i.e. pragmas
-    @create: bool controls whethter to create the db
+    @create: bool controls whether to create the db
     @mes_level: controls the messaging level, see utils.message
     @log_file: if provided, utils.message writes to the provided file
     '''

--- a/lib/pysixdb.py
+++ b/lib/pysixdb.py
@@ -11,7 +11,7 @@ def SixDB(db_info, settings=None, create=False, mes_level=1, log_file=None):
     @settings: databse settings, i.e. pragmas
     @create: bool controls whethter to create the db
     @mes_level: controls the messaging level, see utils.message
-    @log_file: if provided, the utils.message write to provided file
+    @log_file: if provided, utils.message writes to the provided file
     '''
     db_info = db_info.copy()
     if 'db_type' not in db_info.keys():

--- a/lib/study.py
+++ b/lib/study.py
@@ -1034,9 +1034,3 @@ class Study(object):
             utils.message('Error', content, self.mes_level, self.log_file)
         mk = prefix + '_' + b + suffix
         return mk
-
-    def __del__(self):
-        '''The destructor'''
-        self.db.close()
-        content = 'Database is closed!'
-        utils.message('Message', content, self.mes_level, self.log_file)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -171,7 +171,7 @@ def message(mes_type, content, level=1, log_file=None):
     if mes_type in MES_TYPE.keys():
         mes_level = MES_TYPE[mes_type]
     else:
-        mes_type = 'Unknow'
+        mes_type = 'Unknown'
         mes_level = 1
     if mes_level >= level:
         now = datetime.now()

--- a/templates/config.py
+++ b/templates/config.py
@@ -48,7 +48,7 @@ class MyStudy(Study):
         self.oneturn_sixtrack_output = ['oneturnresult']
         self.oneturn_sixtrack_params.update(machine_params)
         self.sixtrack_params = copy.deepcopy(self.oneturn_sixtrack_params)
-        self.sixtrack_params['turnss'] = 1e6  # number of turns to track
+        self.sixtrack_params['turnss'] = int(1e6)  # number of turns to track (must be int)
         amp = [8, 10, 12]  # The amplitude
         self.sixtrack_params['amp'] = list(zip(amp, amp[1:]))  # Take pairs
         self.sixtrack_params['kang'] = list(range(1, 1 + 1))  # The angle


### PR DESCRIPTION
I merged most of the contents of pysixdb.py into the dbadaptor classes, this removes the unnecessary wrapping of dbadaptor by the now removed SixDB class. As far as I could test, for both the sql and mysql databases, the behaviour is unchanged.