### PR TITLE
Integration fixes and utils.diff

### DIFF
--- a/pysixdesk/lib/preprocess.py
+++ b/pysixdesk/lib/preprocess.py
@@ -163,6 +163,8 @@ def madxjob(madx_config, mask_config):
         content = "Failed to generate actual madx input file!"
         raise Exception(content)
 
+    utils.diff(mask_name, madx_in, logger=logger)
+
     # Begin to execute madx job
     command = madxexe + " " + madx_in
     logger.info("Calling madx %s" % madxexe)
@@ -315,7 +317,9 @@ def sixtrackjob(config, config_re, jobname, **kwargs):
     else:
         content = "The %s file doesn't exist!" % temp1
         raise FileNotFoundError(content)
+
     utils.concatenate_files(output, 'fort.3')
+    utils.diff(source, 'fort.3', logger=logger)
 
     # prepare the other input files
     for key in input_files.values():
@@ -324,7 +328,7 @@ def sixtrackjob(config, config_re, jobname, **kwargs):
             os.symlink(key1, key)
         else:
             raise FileNotFoundError("The required input file %s does not found!" %
-                    key)
+                                    key)
     #if os.path.isfile('../fort.2') and os.path.isfile('../fort.16'):
     #    os.symlink('../fort.2', 'fort.2')
     #    os.symlink('../fort.16', 'fort.16')

--- a/pysixdesk/lib/sixtrack.py
+++ b/pysixdesk/lib/sixtrack.py
@@ -232,7 +232,9 @@ def sixtrackjob(sixtrack_config, config_param, boinc_vars):
         output.insert(1, temp1)
     else:
         raise FileNotFoundError("The %s file doesn't exist!" % temp1)
+
     utils.concatenate_files(output, 'fort.3')
+    utils.diff(source, 'fort.3', logger=logger)
 
     # actually run
     wu_id = sixtrack_config['wu_id']
@@ -292,7 +294,9 @@ def sixtrackjob(sixtrack_config, config_param, boinc_vars):
             output.insert(1, temp1)
         else:
             raise FileNotFoundError("The %s file doesn't exist!" % temp1)
+
         utils.concatenate_files(output, 'fort.3')
+        utils.diff(source, 'fort.3', logger=logger)
 
         # zip all the input files, e.g. fort.3 fort.2 fort.8 fort.16
         input_zip = job_name + '.zip'

--- a/pysixdesk/lib/utils.py
+++ b/pysixdesk/lib/utils.py
@@ -5,6 +5,7 @@ import sys
 import gzip
 import shutil
 import logging
+import difflib
 import traceback
 
 # Gobal variables
@@ -122,6 +123,7 @@ def diff(file1, file2, logger=None, **kwargs):
     for line in difflib.unified_diff(file1_data, file2_data, **kwargs):
         display(line)
     display(f'▲▲▲▲▲▲▲▲▲▲▲▲▲ {file1} --> {file2} diff ▲▲▲▲▲▲▲▲▲▲▲▲▲')
+
 
 def encode_strings(inputs):
     '''Convert list or directory to special-format string'''

--- a/pysixdesk/lib/utils.py
+++ b/pysixdesk/lib/utils.py
@@ -92,6 +92,37 @@ def replace(patterns, replacements, source, dest):
     return status
 
 
+def diff(file1, file2, logger=None, **kwargs):
+    '''
+    Displays the diff of two files.
+
+    Args:
+        file1 (str/path): path to first file for the diff.
+        file2 (str/path): path to second file for the diff.
+        logger (logging.logger, optional): logger with which to display the
+        diff, if None, will use `print`.
+        **kwargs: additional arguments for `difflib.unified_diff`.
+    '''
+
+    if logger is not None and isinstance(logger, logging.Logger):
+        display = logger.info
+    else:
+        display = print
+
+    def get_lines(file):
+        '''Returns the contents of `file`.'''
+        with open(file) as f:
+            f_lines = f.read().split('\n')
+        return f_lines
+
+    file1_data = get_lines(file1)
+    file2_data = get_lines(file2)
+
+    display(f'▼▼▼▼▼▼▼▼▼▼▼▼▼ {file1} --> {file2} diff ▼▼▼▼▼▼▼▼▼▼▼▼▼')
+    for line in difflib.unified_diff(file1_data, file2_data, **kwargs):
+        display(line)
+    display(f'▲▲▲▲▲▲▲▲▲▲▲▲▲ {file1} --> {file2} diff ▲▲▲▲▲▲▲▲▲▲▲▲▲')
+
 def encode_strings(inputs):
     '''Convert list or directory to special-format string'''
     status = False

--- a/tests/integration/mysql/test_mysql.py
+++ b/tests/integration/mysql/test_mysql.py
@@ -24,7 +24,8 @@ class MySqlDB(unittest.TestCase):
         self.assertEqual(self.ws.studies, [self.st_name])
 
         self.st = self.ws.load_study(self.st_name,
-                                     module_path=str(Path(__file__).parents[1] / 'variable_config.py'),
+                                     module_path=str(Path(__file__).parents[1] /
+                                                     'variable_config.py'),
                                      class_name='MySqlConfig')
         self.assertEqual(self.st.db_info['db_type'], 'mysql')
 
@@ -36,10 +37,14 @@ class MySqlDB(unittest.TestCase):
         self.assertEqual(in_files, ['db.ini',
                                     'job_id.list',
                                     'htcondor_run.sub'])
-        self.assertEqual(out_folders, ['1', '2', '3', '4'])
+        where = "status='incomplete'"
+        wu_ids = self.st.db.select('preprocess_wu', ['wu_id'], where)
+        wu_ids = [str(o[0]) for o in wu_ids]
+        self.assertEqual(out_folders, wu_ids)
 
         self.st.submit(0)
-        self.assertEqual(len(self.st.submission.check_running(self.st.study_path)), 4)
+        self.assertEqual(len(self.st.submission.check_running(self.st.study_path)),
+                         len(wu_ids))
 
         print('waiting for preprocess job to finish...')
         while self.st.submission.check_running(self.st.study_path) is None\
@@ -49,9 +54,23 @@ class MySqlDB(unittest.TestCase):
         # TODO: add a check on the output of the preprocess job
 
         self.st.prepare_sixtrack_input()
+
+        # getting the expected list of sixtrack wu_ids.
+        # TODO: test this !
+        where = "status='complete'"
+        pre_wu_ids = self.st.db.select('preprocess_wu', ['wu_id'], where)
+        pre_wu_ids = [p[0] for p in pre_wu_ids]
+        if len(pre_wu_ids) == 1:
+            where = "status='incomplete' and preprocess_id=%s" % str(pre_wu_ids[0])
+        else:
+            where = "status='incomplete' and preprocess_id in %s" % str(pre_wu_ids)
+        six_wu_ids = self.st.db.select('sixtrack_wu', ['wu_id'], where)
+        six_wu_ids = [s[0] for s in six_wu_ids]
         # TODO: add assert here
+
         self.st.submit(1)
-        self.assertEqual(len(self.st.submission.check_running(self.st.study_path)), 8)
+        self.assertEqual(len(self.st.submission.check_running(self.st.study_path)),
+                         len(six_wu_ids))
 
         print('waiting for sxitrack job to finish...')
         while self.st.submission.check_running(self.st.study_path) is None\

--- a/tests/integration/mysql/test_mysql.py
+++ b/tests/integration/mysql/test_mysql.py
@@ -5,9 +5,11 @@ import time
 import sys
 from pathlib import Path
 # give the test runner the import access
-sys.path.insert(0, Path(__file__).parents[2].absolute())
+pysixdesk_path = str(Path(__file__).parents[3].absolute())
+sys.path.insert(0, pysixdesk_path)
+# setting environment variable for htcondor job.
+os.environ['PYTHONPATH'] = f"{pysixdesk_path}:{os.environ['PYTHONPATH']}"
 import pysixdesk
-from pathlib import Path
 
 
 class MySqlDB(unittest.TestCase):
@@ -32,15 +34,15 @@ class MySqlDB(unittest.TestCase):
         self.st.update_db()
 
         self.st.prepare_preprocess_input()
-        in_files = os.listdir(Path(self.st.study_path) / 'preprocess_input')
-        out_folders = os.listdir(Path(self.st.study_path) / 'preprocess_output')
-        self.assertEqual(in_files, ['db.ini',
-                                    'job_id.list',
-                                    'htcondor_run.sub'])
+        in_files = set(os.listdir(Path(self.st.study_path) / 'preprocess_input'))
+        out_folders = set(os.listdir(Path(self.st.study_path) / 'preprocess_output'))
+        self.assertEqual(in_files, set(['db.ini',
+                                        'job_id.list',
+                                        'htcondor_run.sub']))
         where = "status='incomplete'"
         wu_ids = self.st.db.select('preprocess_wu', ['wu_id'], where)
         wu_ids = [str(o[0]) for o in wu_ids]
-        self.assertEqual(out_folders, wu_ids)
+        self.assertEqual(out_folders, set(wu_ids))
 
         self.st.submit(0)
         self.assertEqual(len(self.st.submission.check_running(self.st.study_path)),
@@ -49,21 +51,19 @@ class MySqlDB(unittest.TestCase):
         print('waiting for preprocess job to finish...')
         while self.st.submission.check_running(self.st.study_path) is None\
                 or len(self.st.submission.check_running(self.st.study_path)) >= 1:
-            # sleep for 5 mins
-            time.sleep(60*5)
+            time.sleep(30)
         # TODO: add a check on the output of the preprocess job
 
         self.st.prepare_sixtrack_input()
 
         # getting the expected list of sixtrack wu_ids.
-        # TODO: test this !
         where = "status='complete'"
         pre_wu_ids = self.st.db.select('preprocess_wu', ['wu_id'], where)
-        pre_wu_ids = [p[0] for p in pre_wu_ids]
+        pre_wu_ids = tuple([p[0] for p in pre_wu_ids])
         if len(pre_wu_ids) == 1:
-            where = "status='incomplete' and preprocess_id=%s" % str(pre_wu_ids[0])
+            where = f"status='incomplete' and preprocess_id={pre_wu_ids[0]}"
         else:
-            where = "status='incomplete' and preprocess_id in %s" % str(pre_wu_ids)
+            where = f"status='incomplete' and preprocess_id in {pre_wu_ids}"
         six_wu_ids = self.st.db.select('sixtrack_wu', ['wu_id'], where)
         six_wu_ids = [s[0] for s in six_wu_ids]
         # TODO: add assert here
@@ -75,8 +75,7 @@ class MySqlDB(unittest.TestCase):
         print('waiting for sxitrack job to finish...')
         while self.st.submission.check_running(self.st.study_path) is None\
                 or len(self.st.submission.check_running(self.st.study_path)) >= 1:
-            # sleep for 5 mins
-            time.sleep(60*5)
+            time.sleep(60)
         # TODO: add a check on the output of the sixtrack job
 
     def tearDown(self):

--- a/tests/integration/sql/test_sql.py
+++ b/tests/integration/sql/test_sql.py
@@ -24,7 +24,8 @@ class SqlDB(unittest.TestCase):
         self.assertEqual(self.ws.studies, [self.st_name])
 
         self.st = self.ws.load_study(self.st_name,
-                                     module_path=str(Path(__file__).parents[1] / 'variable_config.py'),
+                                     module_path=str(Path(__file__).parents[1] /
+                                                     'variable_config.py'),
                                      class_name='SqlConfig')
         self.assertEqual(self.st.db_info['db_type'], 'sql')
 
@@ -37,22 +38,40 @@ class SqlDB(unittest.TestCase):
                                     'db.ini',
                                     'job_id.list',
                                     'htcondor_run.sub'])
-        self.assertEqual(out_folders, ['1', '2', '3', '4'])
+        # getting the expected list of preprocess wu_ids.
+        where = "status='incomplete'"
+        wu_ids = self.st.db.select('preprocess_wu', ['wu_id'], where)
+        wu_ids = [str(o[0]) for o in wu_ids]
+        self.assertEqual(out_folders, wu_ids)
 
         self.st.submit(0)
-        self.assertEqual(len(self.st.submission.check_running(self.st.study_path)), 4)
+        self.assertEqual(len(self.st.submission.check_running(self.st.study_path)),
+                         len(wu_ids))
 
         print('waiting for preprocess job to finish...')
         while self.st.submission.check_running(self.st.study_path) is None\
                 or len(self.st.submission.check_running(self.st.study_path)) >= 1:
             # sleep for 5 mins
-            time.sleep(60*5)
+            time.sleep(10)
         # TODO: add a check on the output of the preprocess job
 
-        self.prepare_sixtrack_input()
+        self.st.prepare_sixtrack_input()
+        # getting the expected list of sixtrack wu_ids.
+        # TODO: test this !
+        where = "status='complete'"
+        pre_wu_ids = self.st.db.select('preprocess_wu', ['wu_id'], where)
+        pre_wu_ids = [p[0] for p in pre_wu_ids]
+        if len(pre_wu_ids) == 1:
+            where = "status='incomplete' and preprocess_id=%s" % str(pre_wu_ids[0])
+        else:
+            where = "status='incomplete' and preprocess_id in %s" % str(pre_wu_ids)
+        six_wu_ids = self.st.db.select('sixtrack_wu', ['wu_id'], where)
+        six_wu_ids = [s[0] for s in six_wu_ids]
         # TODO: add assert here
-        self.submit(1)
-        self.assertEqual(len(self.st.submission.check_running(self.st.study_path)), 8)
+
+        self.st.submit(1)
+        self.assertEqual(len(self.st.submission.check_running(self.st.study_path)),
+                         len(six_wu_ids))
 
         print('waiting for sixtrack job to finish...')
         while self.st.submission.check_running(self.st.study_path) is None\

--- a/tests/integration/sql/test_sql.py
+++ b/tests/integration/sql/test_sql.py
@@ -55,21 +55,37 @@ class SqlDB(unittest.TestCase):
             time.sleep(10)
         # TODO: add a check on the output of the preprocess job
 
+<<<<<<< HEAD
         self.st.prepare_sixtrack_input()
         # getting the expected list of sixtrack wu_ids.
         # TODO: test this !
         where = "status='complete'"
         pre_wu_ids = self.st.db.select('preprocess_wu', ['wu_id'], where)
+=======
+        self.prepare_sixtrack_input()
+        # getting the expected list of sixtrack wu_ids.
+        # TODO: test this !
+        where = "status='complete'"
+        pre_wu_ids = self.db.select('preprocess_wu', ['wu_id'], where)
+>>>>>>> 8a7a303... improved integration tests
         pre_wu_ids = [p[0] for p in pre_wu_ids]
         if len(pre_wu_ids) == 1:
             where = "status='incomplete' and preprocess_id=%s" % str(pre_wu_ids[0])
         else:
             where = "status='incomplete' and preprocess_id in %s" % str(pre_wu_ids)
+<<<<<<< HEAD
         six_wu_ids = self.st.db.select('sixtrack_wu', ['wu_id'], where)
         six_wu_ids = [s[0] for s in six_wu_ids]
         # TODO: add assert here
 
         self.st.submit(1)
+=======
+        six_wu_ids = self.db.select('sixtrack_wu', ['wu_id'], where)
+        six_wu_ids = [s[0] for s in six_wu_ids]
+        # TODO: add assert here
+
+        self.submit(1)
+>>>>>>> 8a7a303... improved integration tests
         self.assertEqual(len(self.st.submission.check_running(self.st.study_path)),
                          len(six_wu_ids))
 

--- a/tests/unit/test_dbadaptor.py
+++ b/tests/unit/test_dbadaptor.py
@@ -4,7 +4,8 @@ from contextlib import closing
 from pathlib import Path
 import sys
 # give the test runner the import access
-sys.path.insert(0, Path(__file__).parents[1].absolute())
+pysixdesk_path = str(Path(__file__).parents[2].absolute())
+sys.path.insert(0, pysixdesk_path)
 from pysixdesk.lib import dbadaptor
 
 
@@ -46,9 +47,9 @@ class SQLDatabaseAdaptorTest(unittest.TestCase):
 
         data_m = {'a': [2, 3, 4, 5, 6],
                   'b': [2.23, 3.34, 4.45, 5.56, 6.67],
-                  'c': [b'blabla']*5,
-                  'd': ['blabla']*5,
-                  'e': ['']*5}
+                  'c': [b'blabla'] * 5,
+                  'd': ['blabla'] * 5,
+                  'e': [''] * 5}
         self.db.insertm(self.conn, self.name, data_m)
         with closing(self.conn.cursor()) as c:
             c.execute(f'SELECT * FROM {self.name};')
@@ -117,8 +118,8 @@ class MySQLDatabaseAdaptorTest(unittest.TestCase):
 
         data_m = {'a': [2, 3, 4, 5, 6],
                   'b': [2.23, 3.34, 4.45, 5.56, 6.67],
-                  'c': [b'blabla']*5,
-                  'd': ['blabla']*5}
+                  'c': [b'blabla'] * 5,
+                  'd': ['blabla'] * 5}
                   # 'e': ['']*5}
         self.db.insertm(self.conn, self.name, data_m)
         with closing(self.conn.cursor()) as c:

--- a/tests/unit/test_dbtypedict.py
+++ b/tests/unit/test_dbtypedict.py
@@ -2,7 +2,8 @@ import unittest
 import sys
 from pathlib import Path
 # give the test runner the import access
-sys.path.insert(0, Path(__file__).parents[1].absolute())
+pysixdesk_path = str(Path(__file__).parents[2].absolute())
+sys.path.insert(0, pysixdesk_path)
 from pysixdesk.lib import dbtypedict
 
 

--- a/tests/unit/test_submission.py
+++ b/tests/unit/test_submission.py
@@ -4,7 +4,8 @@ import os
 from pathlib import Path
 import sys
 # give the test runner the import access
-sys.path.insert(0, Path(__file__).parents[1].absolute())
+pysixdesk_path = str(Path(__file__).parents[2].absolute())
+sys.path.insert(0, pysixdesk_path)
 from pysixdesk.lib import submission
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,7 +3,8 @@ import shutil
 from pathlib import Path
 import sys
 # give the test runner the import access
-sys.path.insert(0, Path(__file__).parents[1].absolute())
+pysixdesk_path = str(Path(__file__).parents[2].absolute())
+sys.path.insert(0, pysixdesk_path)
 from pysixdesk.lib import utils
 
 

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -3,7 +3,8 @@ import shutil
 from pathlib import Path
 import sys
 # give the test runner the import access
-sys.path.insert(0, Path(__file__).parents[1].absolute())
+pysixdesk_path = str(Path(__file__).parents[2].absolute())
+sys.path.insert(0, pysixdesk_path)
 from pysixdesk.lib import workspace
 
 


### PR DESCRIPTION
This PR fixes a lot of problems with the integration tests, notably, this fixes the incorrect paths of the imports and checking the job submission is `config.py` independent.

It also adds a `utils.diff` function to print the diff of 2 files, it is very simple and very useful to debug and to make sure the placeholders in the template files are replaced with the correct values during the preprocess and sixtrack jobs. If you disagree, I can remove it.