### PR TITLE
Tiny changes for message display

### DIFF
--- a/pysixdesk/lib/fort2_tools.py
+++ b/pysixdesk/lib/fort2_tools.py
@@ -7,6 +7,7 @@
 # elements at the top of the file
 
 import logging
+from . import utils
 from copy import deepcopy
 
 FORT2_ELEMENT_FIELDS = [
@@ -24,7 +25,7 @@ FORT2_BLOCK_FIELDS = [
     'ELEM'
 ]
 
-LOGGER = logging.getLogger("pysixdesk.fort2_tools")
+LOGGER = utils.condor_logger("fort2_tools")
 
 class Fort2Struct:
     '''Structure containing fort.2 information'''

--- a/pysixdesk/lib/generate_fort2.py
+++ b/pysixdesk/lib/generate_fort2.py
@@ -6,18 +6,16 @@
 
 # Program created for including aperture markers in Sixtrack fort.2 file
 # from a TWISS file, for the Sixtrack-FLUKA coupling
-import os
-import sys
-import logging
 from copy import deepcopy
 
+from . import utils
 from .twiss_tools import *
 from .fort2_tools import *
 
 
 # New keys for apertures with offsets
 VALUES_off = ['APER_1', 'APER_2', 'APER_3', 'APER_4', 'XOFF', 'YOFF']
-LOGGER = logging.getLogger("pysixdesk.generate_fort2")
+LOGGER = utils.condor_logger("generate_fort2")
 
 
 def run(fc2, aperture, survery=None, ldebug=False, lold=False):

--- a/pysixdesk/lib/preprocess.py
+++ b/pysixdesk/lib/preprocess.py
@@ -51,7 +51,7 @@ def run(wu_id, input_info):
         if collimation.lower() == 'true':
             try:
                 coll_config = cf['collimation']
-                status = new_fort2(coll_config)
+                new_fort2(coll_config)
             except Exception:
                 logger.error('Generate new fort2 failed!', exc_info=True)
         if oneturn.lower() == 'true':

--- a/pysixdesk/lib/utils.py
+++ b/pysixdesk/lib/utils.py
@@ -252,11 +252,11 @@ def condor_logger(name):
     h1 = logging.StreamHandler(sys.stdout)
     h1.setFormatter(formatter)
     h1.setLevel(logging.DEBUG)
-    h1.addFilter(lambda record: record.levelno <= logging.INFO)
+    h1.addFilter(lambda record: record.levelno <= logging.WARNING)
 
     h2 = logging.StreamHandler(sys.stderr)
     h2.setFormatter(formatter)
-    h2.setLevel(logging.WARNING)
+    h2.setLevel(logging.ERROR)
 
     logger.addHandler(h1)
     logger.addHandler(h2)


### PR DESCRIPTION
Remove the `error_message` method in `generate_fort2`, and replace with logger.error and raise.
Get logger from `utils.condor_logger` in `generate_fort2` and `fort2_tools`. Because the default stream of logger is sys.err, and `utils.condor_logger` specifiies the streamHandler for logger.